### PR TITLE
Source maps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
-  - 0.10
+  - "0.10"
+  - "0.12"
+  - "iojs"

--- a/index.js
+++ b/index.js
@@ -31,12 +31,17 @@ module.exports = function (opts, cb) {
   //   }
   // ));
 
-  var stream = b.bundle();
-  var bundle = { stream: stream, name: '/bundle.js' };
-  var out = fs.createWriteStream(path.resolve(opts.output));
-  initrdPack(out, [bundle]);
-  out.once('finish', cb);
-  out.once('error', cb);
+  b.bundle(function (err, res) {
+    if (err) {
+      cb(err);
+    } else {
+      var bundle = { buffer: res, name: '/bundle.js' };
+      var out = fs.createWriteStream(path.resolve(opts.output));
+      initrdPack(out, [bundle]);
+      out.once('finish', cb);
+      out.once('error', cb);
+    }
+  });
 };
 
 module.exports.builtins = builtins;

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ module.exports = function (opts, cb) {
           var SourceMapConsumer = require('${require.resolve('source-map')}').SourceMapConsumer;
           var smc = new SourceMapConsumer(__MAP__);
           Error.prepareStackTrace = function (error) {
-            return error.stack.replace(/(^[ ])+:(\\d+):(\\d+)/g, function (match, file, p1, p2) {
+            return error.stack.replace(/([a-z10-9\\.\\/]+):(\\d+):(\\d+)/g, function (match, file, p1, p2) {
               var line = Number(p1);
               var column = Number(p2);
               var original = smc.originalPositionFor({

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "buffer-crc32": "^0.2.5",
     "colors": "^1.1.0",
     "combined-stream": "0.0.7",
+    "format-text": "0.0.3",
     "minimist": "^1.1.1",
     "request": "^2.55.0",
     "shelljs": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "minimist": "^1.1.1",
     "request": "^2.55.0",
     "shelljs": "^0.4.0",
+    "source-map": "^0.4.2",
+    "source-mapper": "^1.0.3",
     "stream-to-buffer": "^0.1.0",
     "streamifier": "^0.1.1",
     "through2": "^0.6.5"

--- a/runtimeify.js
+++ b/runtimeify.js
@@ -16,7 +16,9 @@
 
 require('colors');
 var shell = require('shelljs');
-var argv = require('minimist')(process.argv.slice(2));
+var argv = require('minimist')(process.argv.slice(2), {
+  boolean: 'debug'
+});
 var path = require('path');
 var through = require('through2');
 var bundlePath = path.resolve('./bundle.js');
@@ -32,7 +34,8 @@ var file = path.resolve(arglist[arglist.length - 1]);
 
 require('./')({
   file: file,
-  output: output
+  output: output,
+  debug: argv.debug
 }, function (err) {
   if (err) {
     throw err;

--- a/source-maps.js
+++ b/source-maps.js
@@ -2,13 +2,20 @@
           var SourceMapConsumer = require('{sourceMapPath}').SourceMapConsumer;
           var smc = new SourceMapConsumer({map});
           Error.prepareStackTrace = function (error) {
-            return error.stack.replace(/([a-z10-9\.\/]+):(\d+):(\d+)/g, function (match, file, p1, p2) {
-              var line = Number(p1);
-              var column = Number(p2);
-              var original = smc.originalPositionFor({
-                line: line,
-                column: column
-              });
-              return original.source + ':' + original.line + ':' + original.column;
-            });
+            return error.stack
+              .replace(/[a-z10-9\.\/]+:(\d+):(\d+)/g, function (match, p1, p2) {
+                var line = Number(p1);
+                var column = Number(p2);
+                var original = smc.originalPositionFor({
+                  line: line,
+                  column: column
+                });
+                return original.source + ':' + original.line + ':' + original.column;
+              })
+              .split('\n')
+              .filter(function (row) {
+                return row.indexOf('browser-pack/_prelude.js:1:0') === -1;
+              })
+              .join('\n');
+
           }

--- a/source-maps.js
+++ b/source-maps.js
@@ -1,0 +1,14 @@
+
+          var SourceMapConsumer = require('{sourceMapPath}').SourceMapConsumer;
+          var smc = new SourceMapConsumer({map});
+          Error.prepareStackTrace = function (error) {
+            return error.stack.replace(/([a-z10-9\.\/]+):(\d+):(\d+)/g, function (match, file, p1, p2) {
+              var line = Number(p1);
+              var column = Number(p2);
+              var original = smc.originalPositionFor({
+                line: line,
+                column: column
+              });
+              return original.source + ':' + original.line + ':' + original.column;
+            });
+          }


### PR DESCRIPTION
enable by doing `runtimeify({ debug: true...` or `runtimeify --debug`

Instead of

``` shell
Error: E_IPADDRESS_EXPECTED
    at Object.require.26 (/bundle.js:1538:32)
    at s (/bundle.js:1:262)
    at /bundle.js:1:313
    at Object.require.38../ip4-address (/bundle.js:2650:16)
    at s (/bundle.js:1:262)
    at /bundle.js:1:313
    at Object.require.40../interfaces (/bundle.js:2787:17)
    at s (/bundle.js:1:262)
    at /bundle.js:1:313
    at Object.require.23../icmp (/bundle.js:1404:11)
```

You'll see something like

```
Error: E_IPADDRESS_EXPECTED
    at Object.require.26 (node_modules/runtimejs/core/net/net-error.js:23:0)
    at s (../runtimeify/node_modules/browserify/node_modules/browser-pack/_prelude.js:1:0)
    at ../runtimeify/node_modules/browserify/node_modules/browser-pack/_prelude.js:1:0
    at Object.require.38..node_modules/runtimejs/core/net/udp-socket.js:21:0)
    at s (../runtimeify/node_modules/browserify/node_modules/browser-pack/_prelude.js:1:0)
    at ../runtimeify/node_modules/browserify/node_modules/browser-pack/_prelude.js:1:0
    at Object.require.40..node_modules/runtimejs/core/net/udp.js:17:0)
    at s (../runtimeify/node_modules/browserify/node_modules/browser-pack/_prelude.js:1:0)
    at ../runtimeify/node_modules/browserify/node_modules/browser-pack/_prelude.js:1:0
    at Object.require.23..node_modules/runtimejs/core/net/ip4.js:18:0)
```
