### PR TITLE
Add runtime-node-net, runtime-node-dns, and http-node

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,8 +18,9 @@ var fs = require('fs');
 var path = require('path');
 var builtins = require('browserify/lib/builtins');
 
-builtins.http = require.resolve('http-node');
+builtins.dns = require.resolve('runtime-node-dns');
 builtins.net = require.resolve('runtime-node-net');
+builtins.http = require.resolve('http-node');
 
 module.exports = function (opts, cb) {
   var b = browserify(opts.file, opts);

--- a/index.js
+++ b/index.js
@@ -18,6 +18,9 @@ var fs = require('fs');
 var path = require('path');
 var builtins = require('browserify/lib/builtins');
 
+builtins.http = require.resolve('http-node');
+builtins.net = require.resolve('runtime-node-net');
+
 module.exports = function (opts, cb) {
   var b = browserify(opts.file, opts);
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "stream-to-buffer": "^0.1.0",
     "streamifier": "^0.1.1",
     "through2": "^0.6.5",
-    "runtimejs": "^0.1.14",
     "runtime-node-net": "^0.1.0",
     "runtime-node-dns": "^1.1.1",
     "http-node": "^0.0.1"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,11 @@
   },
   "homepage": "http://runtimejs.org",
   "devDependencies": {
-    "tape": "^4.0.0"
+    "tape": "^4.0.0",
+    "runtimejs": "^0.1.14",
+    "runtime-node-net": "^0.1.0",
+    "runtime-node-dns": "^1.1.1",
+    "http-node": "^0.0.1"
   },
   "dependencies": {
     "async": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -20,11 +20,7 @@
   },
   "homepage": "http://runtimejs.org",
   "devDependencies": {
-    "tape": "^4.0.0",
-    "runtimejs": "^0.1.14",
-    "runtime-node-net": "^0.1.0",
-    "runtime-node-dns": "^1.1.1",
-    "http-node": "^0.0.1"
+    "tape": "^4.0.0"
   },
   "dependencies": {
     "async": "^0.9.0",
@@ -37,6 +33,10 @@
     "shelljs": "^0.4.0",
     "stream-to-buffer": "^0.1.0",
     "streamifier": "^0.1.1",
-    "through2": "^0.6.5"
+    "through2": "^0.6.5",
+    "runtimejs": "^0.1.14",
+    "runtime-node-net": "^0.1.0",
+    "runtime-node-dns": "^1.1.1",
+    "http-node": "^0.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   },
   "homepage": "http://runtimejs.org",
   "devDependencies": {
-    "tape": "^4.0.0"
+    "tape": "^4.0.0",
+    "runtimejs": "*"
   },
   "dependencies": {
     "async": "^0.9.0",

--- a/test/bundle_index.js
+++ b/test/bundle_index.js
@@ -16,3 +16,7 @@ var runtime = require('runtimejs');
 var foo = require('./foo');
 console.log(foo(2));
 
+// Test builtins:
+var dns = require('dns');
+var net = require('net');
+var http = require('http');


### PR DESCRIPTION
This fixes issue #5 by adding `runtime-node-net` -> `net`, `runtime-node-dns` -> `dns`, and `http-node` -> `http`. Also adds a test for them.
